### PR TITLE
eabartlett: write namespaces to nodes on #to_xml

### DIFF
--- a/lib/roxml.rb
+++ b/lib/roxml.rb
@@ -44,6 +44,8 @@ module ROXML # :nodoc:
         end
         if params[:namespaces]
           params[:namespaces].each { |prefix, url| root.add_namespace_definition(prefix, url) }
+        elsif self.class.roxml_namespaces
+          self.class.roxml_namespaces.each { |prefix, url| root.add_namespace_definition(prefix, url) }
         end
       end
     end

--- a/spec/xml/namespaces_spec.rb
+++ b/spec/xml/namespaces_spec.rb
@@ -64,4 +64,37 @@ describe ROXML, "#xml_namespaces" do
       end
     end
   end
+  describe "for writing" do
+    class NamespacedNode
+      include ROXML
+
+      xml_namespaces \
+        :ns1 => 'http://example.com',
+        :ns2 => 'http://example2.com'
+
+      xml_accessor :ex1
+    end
+
+    class RootNode
+      include ROXML
+
+      xml_name "RootNode"
+
+      xml_accessor :node, :from => "NamespacedNode", as: NamespacedNode
+    end
+
+    before do
+       @xml = %{
+<RootNode>
+  <NamespacedNode xmlns:ns1="http://example.com" xmlns:ns2="http://example2.com">
+    <ex1>1</ex1>
+  </NamespacedNode>
+</RootNode>
+       }
+    end
+
+    it "should write out namespaces in middle node" do
+      expect(RootNode.from_xml(@xml).to_xml.to_s).to eq(@xml.strip)
+    end
+  end
 end


### PR DESCRIPTION
Adding support for writing out namespaces was a future goal of ROXML, but was never completed. Adding in here so we can use.